### PR TITLE
MAINT: rename token

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -206,7 +206,7 @@ jobs:
         if: github.event_name == 'schedule' && github.repository == 'scipy/scipy-release'
         shell: bash -el {0}  # required for micromamba
         env:
-          TOKEN: ${{ secrets.scipy_NIGHTLY_UPLOAD_TOKEN }}
+          TOKEN: ${{ secrets.SCIPY_NIGHTLY_UPLOAD_TOKEN }}
         run: |
           anaconda -q -t ${TOKEN} upload --force -u scientific-python-nightly-wheels ./dist/*.whl
 


### PR DESCRIPTION
Not quite clear why the scheduled upload has an error message about uploading. The invocation is the same as numpy's. Wondering if it's to do with capitalisation of the secret. I checked the secret name is spelled correctly.

```
/Users/runner/micromamba/envs/upload-env/lib/python3.14/site-packages/binstar_client/__init__.py:16: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import parse_version as pv
/Users/runner/micromamba/envs/upload-env/lib/python3.14/site-packages/binstar_client/commands/authorizations.py:262: PendingDeprecationWarning: FileType is deprecated. Simply open files after parsing arguments.
  token_group.add_argument('--out', default=sys.stdout, type=argparse.FileType('w'))
usage: anaconda [-h] [--disable-ssl-warnings] [--show-traceback] [-v] [-q]
                [-t TOKEN] [-s SITE] [-V]
                 ...
anaconda: error: argument : invalid choice: 'scientific-python-nightly-wheels' (choose from auth, label, channel, config, copy, download, groups, login, logout, move, notebook, package, remove, search, show, update, upload, whoami)
```