### PR TITLE
BLD: build on maintenance branch (testpypi)

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,7 +4,7 @@ env:
   # A tag or branch name or a commit hash for the scipy/scipy repo, for which
   # to build wheels. This is normally set to `main` in the main branch of this
   # repo, and to a tag name (e.g., `v2.3.2`) on a release branch.
-  SOURCE_REF_TO_BUILD: main
+  SOURCE_REF_TO_BUILD: maintenance/1.17.x
 
 on:
   schedule:


### PR DESCRIPTION
I'm experimenting with the release process and trusted publishing. I have just made a `maintenance/1.17.x` branch and am making this PR to tell wheels (on this maintenance branch) to be made against the `scipy/scipy@maintenance/1.17.x` branch. 