### PR TITLE
CI: change how nightlies are uploaded

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -189,7 +189,7 @@ jobs:
           name: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}-${{ matrix.buildplat[3] }}-${{ matrix.buildplat[4] }}
 
 # -------------------------------------------------------------------------------------
-  # Should we upload to nightly. We do this on a scheduled run, or a workflow dispatch with environment none'
+  # Should we upload to nightly. We do this on a scheduled run, or a workflow dispatch with environment 'none'
   nightly_upload:
     runs-on: ubuntu-latest
     if: github.repository == 'scipy/scipy-release' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'none'))
@@ -205,18 +205,18 @@ jobs:
       - name: Install micromamba
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
-        # For installation of anaconda-client, required for upload to anaconda.org
-        init-shell: bash
-        environment-name: upload-env
-        create-args: >-
-          anaconda-client
+          # For installation of anaconda-client, required for upload to anaconda.org
+          init-shell: bash
+          environment-name: upload-env
+          create-args: >-
+            anaconda-client
 
-    - name: Upload to anaconda.org
-      shell: bash -el {0}  # required for micromamba
-      env:
-        TOKEN: ${{ secrets.SCIPY_NIGHTLY_UPLOAD_TOKEN }}
-      run: |
-        anaconda -q -t ${TOKEN} upload --force -u scientific-python-nightly-wheels ./dist/*.whl
+      - name: Upload to anaconda.org
+        shell: bash -el {0}  # required for micromamba
+        env:
+          TOKEN: ${{ secrets.SCIPY_NIGHTLY_UPLOAD_TOKEN }}
+        run: |
+          anaconda -q -t ${TOKEN} upload --force -u scientific-python-nightly-wheels ./dist/*.whl
 
 # -------------------------------------------------------------------------------------
   build_sdist:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -188,33 +188,35 @@ jobs:
           path: ./dist/*.whl
           name: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}-${{ matrix.buildplat[3] }}-${{ matrix.buildplat[4] }}
 
-      # We upload nightlies only on cron job runs, so it doesn't overlap with
-      # builds from which we publish to PyPI - we don't want these extra
-      # dependencies when building release artifacts.
-      - name: install micromamba
-        # win-arm64 is unsupported by micromamba at the moment
-        if:  matrix.buildplat[0] != 'windows-11-arm' && github.event_name == 'schedule'
+# -------------------------------------------------------------------------------------
+  # Should we upload to nightly. We do this on a scheduled run, or a workflow dispatch with environment none'
+  nightly_upload:
+    runs-on: ubuntu-latest
+    if: github.repository == 'scipy/scipy-release' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'none'))
+    needs: [build_wheels]
+
+    steps:
+      - name: Download wheels
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Install micromamba
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
-          # For installation of anaconda-client, required for upload to anaconda.org
-          init-shell: bash
-          environment-name: upload-env
-          create-args: >-
-            anaconda-client
+        # For installation of anaconda-client, required for upload to anaconda.org
+        init-shell: bash
+        environment-name: upload-env
+        create-args: >-
+          anaconda-client
 
-      - name: win-arm64 install anaconda client
-        if: matrix.buildplat[1] == 'win' && matrix.buildplat[2] == 'ARM64' && github.event_name == 'schedule'
-        run: |
-          pip install --only-binary :all: anaconda-client
-
-
-      - name: Upload to anaconda.org
-        if: github.event_name == 'schedule' && github.repository == 'scipy/scipy-release'
-        shell: bash -el {0}  # required for micromamba
-        env:
-          TOKEN: ${{ secrets.SCIPY_NIGHTLY_UPLOAD_TOKEN }}
-        run: |
-          anaconda -q -t ${TOKEN} upload --force -u scientific-python-nightly-wheels ./dist/*.whl
+    - name: Upload to anaconda.org
+      shell: bash -el {0}  # required for micromamba
+      env:
+        TOKEN: ${{ secrets.SCIPY_NIGHTLY_UPLOAD_TOKEN }}
+      run: |
+        anaconda -q -t ${TOKEN} upload --force -u scientific-python-nightly-wheels ./dist/*.whl
 
 # -------------------------------------------------------------------------------------
   build_sdist:


### PR DESCRIPTION
@rgommers, how about this for uploading nightlies? Upload nightlies if:
`github.repository == 'scipy/scipy-release' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'none'))`

It consolidates all the uploads into a single step. This has the advantage of not having to fiddle around with a winarm64 `anaconda-client`. However, if does mean that if a matrix entry fails then none of the wheels get uploaded. Previously only the failing entries would not be uploaded.