### PR TITLE
CI: investigate win_AMD64 fails

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -89,6 +89,9 @@ jobs:
         if: ${{ matrix.buildplat[1] == 'win' && matrix.buildplat[2] == 'AMD64' }}
         run: |
           echo "c:\rtools45\ucrt64\bin" >> $env:GITHUB_PATH
+          
+          # workaround for https://github.com/scipy/scipy/issues/25067
+          rm -fo c:/Strawberry/c/lib/pkgconfig/*.pc
 
       - name: win_arm64 - set environment variables
         if: matrix.buildplat[1] == 'win' && matrix.buildplat[2] == 'ARM64'
@@ -170,7 +173,7 @@ jobs:
           echo "CIBW_REPAIR_WHEEL_COMMAND_MACOS=$CIBW" >> "$GITHUB_ENV"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@ee02a1537ce3071a004a6b08c41e72f0fdc42d9a # v3.4.0
+        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
         env:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}
@@ -180,7 +183,7 @@ jobs:
            output-dir: dist
            config-file: cibuildwheel.toml
 
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: ./dist/*.whl
           name: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}-${{ matrix.buildplat[3] }}-${{ matrix.buildplat[4] }}
@@ -255,7 +258,7 @@ jobs:
           cd .. # Can't import scipy within scipy src directory
           python -c "import scipy, sys; print(scipy.__version__); sys.exit(scipy.test() is False)"
 
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sdist
           path: ./dist/*
@@ -279,7 +282,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
@@ -336,7 +339,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           print-hash: true
           attestations: true


### PR DESCRIPTION
Provides a workaround for https://github.com/scipy/scipy/issues/25067. However, an underlying fix in cython/meson/cibuildwheel may also be needed.

@rgommers 