### PR TITLE
MAINT: remove cp313t (free-threaded 3.13) jobs

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -62,7 +62,7 @@ jobs:
         - [macos-14, macosx, arm64, accelerate, "14.0"]
         - [windows-2025, win, AMD64, "", ""]
         - [windows-11-arm, win, ARM64, "", ""]
-        python: [["cp312", "3.12"], ["cp313", "3.13"], ["cp313t", "3.13"], ["cp314", "cp314"], ["cp314t", "cp314"]]
+        python: [["cp312", "3.12"], ["cp313", "3.13"], ["cp314", "cp314"], ["cp314t", "cp314"]]
         # python[0] is used to specify the python versions made by cibuildwheel
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ it's recommended to only select the platform(s) you're interested in like this:
 -          - [windows-2022, win_amd64, ""]
 -          - [windows-2022, win32, ""]
 -          - [windows-11-arm, win_arm64, ""]
--        python: ["cp311", "cp312", "cp313", "cp313t", "cp314", "cp314t", "pp311"]
+-        python: ["cp312", "cp313", "cp314", "cp314t"]
 +        python: ["cp314", "cp314t"]
          exclude:
            # Don't build PyPy 32-bit windows


### PR DESCRIPTION
`manylinux` and `cibuildwheel` are dropping support, so 3.13t support is being removed throughout the ecosystem. See, e.g., cibuildwheel#2683.