### PR TITLE
MAINT, REL: initial test of 1.18.x wheel builds

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,7 +4,7 @@ env:
   # A tag or branch name or a commit hash for the scipy/scipy repo, for which
   # to build wheels. This is normally set to `main` in the main branch of this
   # repo, and to a tag name (e.g., `v2.3.2`) on a release branch.
-  SOURCE_REF_TO_BUILD: main
+  SOURCE_REF_TO_BUILD: maintenance/1.18.x
 
 on:
   schedule:


### PR DESCRIPTION
* The `maintenance/1.18.x` branch has been pushed up in both the `scipy` and `scipy-release` repos now (step 1 in gh-10).

* This is the initial check that the wheel builds on the new maintenance branch are looking "ok"
(step 2 at gh-10).

* I still have interest in merging a few more backports in the main repo before the RC1 release (some may fix failures that could show up here), but we'll see how the timing on that works out with code reviews and a long weekend in many places.