### PR TITLE
MAINT: fix sdist job, which relies on requirements/test.txt in scipy/scipy

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -212,7 +212,7 @@ jobs:
       - name: Test the sdist
         run: |
           python -m pip install -v dist/*.gz
-          pip install -r $GITHUB_WORKSPACE/requirements/test.txt
+          pip install pytest hypothesis pooch
           cd .. # Can't import scipy within scipy src directory
           python -c "import scipy, sys; print(scipy.__version__); sys.exit(scipy.test() is False)"
 


### PR DESCRIPTION
This wasn't pinned, still isn't pinned. Opening a follow-up issue for that, for now just getting CI green again.

In the main repo we removed some of these requirements files and started using dependency groups in `pyproject.toml` instead. Not changing to that, but rather adding the minimal fix. None of these options were actually fulled pinned, not only because `==` wasn't used, but because there are transitive dependencies. Goes for wheel builds as well. 