### PR TITLE
BLD: offload some requirements files to scipy

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -84,17 +84,17 @@ jobs:
         with:
           python-version: 3.13
 
-      - name: win_amd64 - configure compilers
-        if: ${{ matrix.buildplat[1] == 'win' && matrix.buildplat[2] == 'AMD64' }}
-        run: |
-          echo "CC=gcc" >> $env:GITHUB_ENV
-          echo "CXX=g++" >> $env:GITHUB_ENV
-
-          # workaround for https://github.com/scipy/scipy/issues/25067
-          rm -fo c:/Strawberry/c/lib/pkgconfig/*.pc
+#      - name: win_amd64 - configure compilers
+#        if: ${{ matrix.buildplat[1] == 'win' && matrix.buildplat[2] == 'AMD64' }}
+#        run: |
+#          echo "CC=gcc" >> $env:GITHUB_ENV
+#          echo "CXX=g++" >> $env:GITHUB_ENV
+#
+#          # workaround for https://github.com/scipy/scipy/issues/25067
+#          rm -fo c:/Strawberry/c/lib/pkgconfig/*.pc
 
       - name: win_arm64 - configure compilers
-        if: matrix.buildplat[1] == 'win' && matrix.buildplat[2] == 'ARM64'
+        if: matrix.buildplat[1] == 'win' #&& matrix.buildplat[2] == 'ARM64'
         run: |
             echo "CC=clang-cl" >> $env:GITHUB_ENV
             echo "CXX=clang-cl" >> $env:GITHUB_ENV

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -84,28 +84,18 @@ jobs:
         with:
           python-version: 3.13
 
-#      - name: win_amd64 - configure compilers
-#        if: ${{ matrix.buildplat[1] == 'win' && matrix.buildplat[2] == 'AMD64' }}
-#        run: |
-#          echo "CC=gcc" >> $env:GITHUB_ENV
-#          echo "CXX=g++" >> $env:GITHUB_ENV
-#
-#          # workaround for https://github.com/scipy/scipy/issues/25067
-#          rm -fo c:/Strawberry/c/lib/pkgconfig/*.pc
-
-      - name: win_arm64 - configure compilers
-        if: matrix.buildplat[1] == 'win' #&& matrix.buildplat[2] == 'ARM64'
+      - name: Setup windows
+        if: matrix.buildplat[1] == 'win'
         run: |
-            echo "C:\Program Files\LLVM\bin" >> $env:GITHUB_PATH
-            echo "CC=clang-cl" >> $env:GITHUB_ENV
-            echo "CXX=clang-cl" >> $env:GITHUB_ENV
-            echo "TARGET_ARCH=${{ matrix.buildplat[2] }}" >> $env:GITHUB_ENV
-            # workaround for https://github.com/scipy/scipy/issues/25067
-            rm -fo c:/Strawberry/c/lib/pkgconfig/*.pc
+          echo "C:\Program Files\LLVM\bin" >> $env:GITHUB_PATH
+          echo "CC=clang-cl" >> $env:GITHUB_ENV
+          echo "CXX=clang-cl" >> $env:GITHUB_ENV
+          echo "TARGET_ARCH=${{ matrix.buildplat[2] }}" >> $env:GITHUB_ENV
 
-      - name: pkg-config-for-win
-        if: runner.os == 'windows'
-        run: |
+          # workaround for https://github.com/scipy/scipy/issues/25067
+          rm -fo c:/Strawberry/c/lib/pkgconfig/*.pc
+
+          # pkg-config setup
           $CIBW = "${{ github.workspace }}/.openblas"
           # pkgconfig needs a complete path, and not just "./openblas since the
           # build is run in a tmp dir (?)

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -100,6 +100,8 @@ jobs:
             echo "CC=clang-cl" >> $env:GITHUB_ENV
             echo "CXX=clang-cl" >> $env:GITHUB_ENV
             echo "TARGET_ARCH=${{ matrix.buildplat[2] }}" >> $env:GITHUB_ENV
+            # workaround for https://github.com/scipy/scipy/issues/25067
+            rm -fo c:/Strawberry/c/lib/pkgconfig/*.pc
 
       - name: pkg-config-for-win
         if: runner.os == 'windows'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -96,6 +96,7 @@ jobs:
       - name: win_arm64 - configure compilers
         if: matrix.buildplat[1] == 'win' #&& matrix.buildplat[2] == 'ARM64'
         run: |
+            echo "C:\Program Files\LLVM\bin" >> $env:GITHUB_PATH
             echo "CC=clang-cl" >> $env:GITHUB_ENV
             echo "CXX=clang-cl" >> $env:GITHUB_ENV
             echo "TARGET_ARCH=${{ matrix.buildplat[2] }}" >> $env:GITHUB_ENV

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -84,19 +84,18 @@ jobs:
         with:
           python-version: 3.13
 
-      # needed for pkg-config. No longer needed for gfortran
-      - name: win_amd64 - install rtools
+      - name: win_amd64 - configure compilers
         if: ${{ matrix.buildplat[1] == 'win' && matrix.buildplat[2] == 'AMD64' }}
         run: |
-          echo "c:\rtools45\ucrt64\bin" >> $env:GITHUB_PATH
-          
+          echo "CC=gcc" >> $env:GITHUB_ENV
+          echo "CXX=g++" >> $env:GITHUB_ENV
+
           # workaround for https://github.com/scipy/scipy/issues/25067
           rm -fo c:/Strawberry/c/lib/pkgconfig/*.pc
 
-      - name: win_arm64 - set environment variables
+      - name: win_arm64 - configure compilers
         if: matrix.buildplat[1] == 'win' && matrix.buildplat[2] == 'ARM64'
         run: |
-            echo "C:\Program Files\LLVM\bin" >> $env:GIHUB_PATH
             echo "CC=clang-cl" >> $env:GITHUB_ENV
             echo "CXX=clang-cl" >> $env:GITHUB_ENV
             echo "TARGET_ARCH=${{ matrix.buildplat[2] }}" >> $env:GITHUB_ENV

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -193,7 +193,7 @@ jobs:
           rm -rf $pkgconf_path
           mkdir -p $pkgconf_path
 
-          python -m pip install -r $GITHUB_WORKSPACE/requirements/openblas.txt
+          python -m pip install --group $OPENBLAS
           python -c "import scipy_${OPENBLAS}; print(scipy_${OPENBLAS}.get_pkg_config())" > $pkgconf_path/scipy-openblas.pc
           export PKG_CONFIG_PATH=$pkgconf_path
           echo "PKG_CONFIG_PATH=$pkgconf_path" >> "$GITHUB_ENV"

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -1,4 +1,4 @@
-The openblas and test requirements are sourced from the cloned scipy repository folder.
-This is typically $GITHUB_WORKSPACE/scipy-src/requirements/{openblas,test}.txt.
+openblas, delvewheel, pkgconf requirements are sourced from the cloned scipy repository folder.
+This is typically $GITHUB_WORKSPACE/scipy-src/requirements/<requirement>.txt.
 
 This makes it easier to keep in sync with the main repository.

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -1,4 +1,4 @@
-openblas, delvewheel, pkgconf requirements are sourced from the cloned scipy repository folder.
+openblas, pkgconf requirements are sourced from the cloned scipy repository folder.
 This is typically $GITHUB_WORKSPACE/scipy-src/requirements/<requirement>.txt.
 
 This makes it easier to keep in sync with the main repository.

--- a/requirements/delvewheel_requirements.txt
+++ b/requirements/delvewheel_requirements.txt
@@ -1,2 +1,0 @@
-delvewheel==1.11.1 ; sys_platform == 'win32'
-wheel

--- a/requirements/pkgconf.txt
+++ b/requirements/pkgconf.txt
@@ -1,1 +1,0 @@
-pkgconf==2.5.1.post1

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -60,7 +60,6 @@ fi
 
 # cibuildwheel doesn't install delvewheel by default
 if [[ $RUNNER_OS == "Windows" ]]; then
-    python -m pip install -r $PROJECT_DIR/scipy-src/requirements/delvewheel_requirements.txt
     # pkgconf - carries out the role of pkg-config.
     # Alternative is pkgconfiglite that you have to install with choco
     python -m pip install -r $PROJECT_DIR/scipy-src/requirements/pkgconf.txt

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -60,8 +60,8 @@ fi
 
 # cibuildwheel doesn't install delvewheel by default
 if [[ $RUNNER_OS == "Windows" ]]; then
-    python -m pip install -r $PROJECT_DIR/requirements/delvewheel_requirements.txt
+    python -m pip install -r $PROJECT_DIR/scipy-src/requirements/delvewheel_requirements.txt
     # pkgconf - carries out the role of pkg-config.
     # Alternative is pkgconfiglite that you have to install with choco
-    python -m pip install -r $PROJECT_DIR/requirements/pkgconf.txt
+    python -m pip install -r $PROJECT_DIR/scipy-src/requirements/pkgconf.txt
 fi

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -44,7 +44,7 @@ if [[ "$INSTALL_OPENBLAS" = "true" ]] ; then
     rm -rf $pkgconf_path
     mkdir -p $pkgconf_path
     pushd $PROJECT_DIR/scipy-src
-    python -m pip install --group openblas32
+    python -m pip install --group ${OPENBLAS}
     popd
     python -c "import scipy_${OPENBLAS}; print(scipy_${OPENBLAS}.get_pkg_config())" > $pkgconf_path/scipy-openblas.pc
 

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -60,7 +60,6 @@ fi
 
 # cibuildwheel doesn't install delvewheel by default
 if [[ $RUNNER_OS == "Windows" ]]; then
-    python -m pip install wheel
     # pkgconf - carries out the role of pkg-config.
     # Alternative is pkgconfiglite that you have to install with choco
     python -m pip install -r $PROJECT_DIR/scipy-src/requirements/pkgconf.txt

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -43,7 +43,9 @@ if [[ "$INSTALL_OPENBLAS" = "true" ]] ; then
     echo pkgconf_path is $pkgconf_path, OPENBLAS is ${OPENBLAS}
     rm -rf $pkgconf_path
     mkdir -p $pkgconf_path
-    python -m pip install -r $PROJECT_DIR/scipy-src/requirements/openblas.txt
+    pushd $PROJECT_DIR/scipy-src
+    python -m pip install --group openblas32
+    popd
     python -c "import scipy_${OPENBLAS}; print(scipy_${OPENBLAS}.get_pkg_config())" > $pkgconf_path/scipy-openblas.pc
 
     # Copy scipy-openblas DLL's to a fixed location so we can point delvewheel

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -60,6 +60,7 @@ fi
 
 # cibuildwheel doesn't install delvewheel by default
 if [[ $RUNNER_OS == "Windows" ]]; then
+    python -m pip install wheel
     # pkgconf - carries out the role of pkg-config.
     # Alternative is pkgconfiglite that you have to install with choco
     python -m pip install -r $PROJECT_DIR/scipy-src/requirements/pkgconf.txt

--- a/tools/wheels/repair_windows.sh
+++ b/tools/wheels/repair_windows.sh
@@ -8,33 +8,33 @@ OPENBLAS_DIR=$(python -c"import scipy_openblas32 as sop; print(sop.get_lib_dir()
 # TARGET_ARCH should be set by the CI environment (e.g., ARM64, AMD64)
 TARGET_ARCH="${TARGET_ARCH:-}" # Default to empty string if not set
 
-if [ "$TARGET_ARCH" = "ARM64" ]; then
-  echo "Skipping stripping for ARM64 target."
-else
-  echo "Performing stripping for AMD64 target."
-
-  # create a temporary directory in the destination folder and unpack the wheel
-  # into there
-  pushd $DEST_DIR
-  mkdir -p tmp
-  pushd tmp
-  wheel unpack $WHEEL
-  pushd scipy*
-
-  # To avoid DLL hell, the file name of libopenblas that's being vendored with
-  # the wheel has to be name-mangled. delvewheel is unable to name-mangle PYD
-  # containing extra data at the end of the binary, which frequently occurs when
-  # building with mingw.
-  # We therefore find each PYD in the directory structure and strip them.
-
-  for f in $(find ./scipy* -name '*.pyd'); do strip $f; done
-
-  # now repack the wheel and overwrite the original
-  wheel pack .
-  mv -fv *.whl $WHEEL
-
-  cd $DEST_DIR
-  rm -rf tmp
-fi
+#if [ "$TARGET_ARCH" = "ARM64" ]; then
+#  echo "Skipping stripping for ARM64 target."
+#else
+#  echo "Performing stripping for AMD64 target."
+#
+#  # create a temporary directory in the destination folder and unpack the wheel
+#  # into there
+#  pushd $DEST_DIR
+#  mkdir -p tmp
+#  pushd tmp
+#  wheel unpack $WHEEL
+#  pushd scipy*
+#
+#  # To avoid DLL hell, the file name of libopenblas that's being vendored with
+#  # the wheel has to be name-mangled. delvewheel is unable to name-mangle PYD
+#  # containing extra data at the end of the binary, which frequently occurs when
+#  # building with mingw.
+#  # We therefore find each PYD in the directory structure and strip them.
+#
+#  for f in $(find ./scipy* -name '*.pyd'); do strip $f; done
+#
+#  # now repack the wheel and overwrite the original
+#  wheel pack .
+#  mv -fv *.whl $WHEEL
+#
+#  cd $DEST_DIR
+#  rm -rf tmp
+#fi
 
 delvewheel repair --add-path $OPENBLAS_DIR --no-dll libsf_error_state.dll -w $DEST_DIR $WHEEL

--- a/tools/wheels/repair_windows.sh
+++ b/tools/wheels/repair_windows.sh
@@ -4,37 +4,4 @@ WHEEL="$1"
 DEST_DIR="$2"
 OPENBLAS_DIR=$(python -c"import scipy_openblas32 as sop; print(sop.get_lib_dir())")
 
-# Skip the strip command based on TARGET_ARCH
-# TARGET_ARCH should be set by the CI environment (e.g., ARM64, AMD64)
-TARGET_ARCH="${TARGET_ARCH:-}" # Default to empty string if not set
-
-#if [ "$TARGET_ARCH" = "ARM64" ]; then
-#  echo "Skipping stripping for ARM64 target."
-#else
-#  echo "Performing stripping for AMD64 target."
-#
-#  # create a temporary directory in the destination folder and unpack the wheel
-#  # into there
-#  pushd $DEST_DIR
-#  mkdir -p tmp
-#  pushd tmp
-#  wheel unpack $WHEEL
-#  pushd scipy*
-#
-#  # To avoid DLL hell, the file name of libopenblas that's being vendored with
-#  # the wheel has to be name-mangled. delvewheel is unable to name-mangle PYD
-#  # containing extra data at the end of the binary, which frequently occurs when
-#  # building with mingw.
-#  # We therefore find each PYD in the directory structure and strip them.
-#
-#  for f in $(find ./scipy* -name '*.pyd'); do strip $f; done
-#
-#  # now repack the wheel and overwrite the original
-#  wheel pack .
-#  mv -fv *.whl $WHEEL
-#
-#  cd $DEST_DIR
-#  rm -rf tmp
-#fi
-
 delvewheel repair --add-path $OPENBLAS_DIR --no-dll libsf_error_state.dll -w $DEST_DIR $WHEEL


### PR DESCRIPTION
- tidies up some comments in the wheels configuration.
- delvewheel is supplied by cibuildwheel now.
- uses requirements files from the scipy/scipy repository (openblas/pkgconf) instead of hosting them here. Would these be better off being added as dependency groups in the source repo pyproject.toml?